### PR TITLE
Fix mobile header layout: integrate theme toggle into navigation

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -72,8 +72,23 @@
 }
 
 @media (max-width: 768px) {
+  .nav-container {
+    /* Ensure proper layout: logo | theme-toggle | hamburger */
+    display: flex;
+    align-items: center;
+    gap: 0;
+  }
+
   .nav-toggle {
     display: block;
+    /* Keep hamburger on the right */
+    order: 3;
+    margin-left: var(--spacing-sm);
+  }
+
+  .nav-logo {
+    /* Logo on the left */
+    order: 1;
   }
 
   .nav-menu {
@@ -915,11 +930,19 @@ main {
 
 @media (max-width: 768px) {
   .theme-switcher {
-    position: fixed;
-    bottom: var(--spacing-md);
-    right: var(--spacing-md);
-    z-index: 100;
-    box-shadow: var(--shadow-card-hover);
+    /* Moved into header between logo and hamburger */
+    position: static;
+    order: 2;
+    margin-right: auto;
+    margin-left: var(--spacing-md);
+    box-shadow: none;
+    background: rgba(26, 26, 26, 0.05);
+    padding: 4px;
+    border-radius: 6px;
+  }
+
+  [data-theme="dark"] .theme-switcher {
+    background: rgba(255, 255, 255, 0.05);
   }
 
   .theme-label {
@@ -928,5 +951,8 @@ main {
 
   .theme-btn {
     padding: 10px;
+    /* Ensure proper touch target size (44x44px minimum) */
+    min-width: 44px;
+    min-height: 44px;
   }
 }


### PR DESCRIPTION
## Summary
- Fixed mobile UX issue where theme toggle was floating at bottom-right
- Moved theme toggle into mobile header navigation between logo and hamburger menu
- Created unified control area following mobile UI best practices

## Changes
- Changed theme toggle position from `fixed` to `static` on mobile viewports
- Added flexbox ordering: logo (order: 1), theme toggle (order: 2), hamburger (order: 3)
- Ensured 44x44px minimum touch targets (WCAG 2.1 Level AAA compliant)
- Added subtle background styling for visual grouping
- Maintained full functionality in both light and dark modes

## Benefits
✓ All controls in natural thumb zone at top of screen
✓ Eliminates floating element cluttering content
✓ Better discoverability of theme controls
✓ Cleaner, more professional mobile layout
✓ Follows iOS/Android mobile UI patterns

## Test Plan
- [x] Verified layout at 375x667 mobile viewport
- [x] Tested theme switching (light/dark/auto modes)
- [x] Confirmed proper element ordering and spacing
- [x] Validated touch target sizes (44x44px minimum)
- [x] Checked both light and dark mode styling

## Screenshots
Available in the test screenshots generated during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)