### PR TITLE
Fix S3 deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,32 +9,57 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
+
       - name: Install dependencies
         run: npm install
+
       - name: Build site (pages + blog)
         run: npm run build
+
       - name: Sync S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete --exclude '.git/*' --exclude 'node_modules/*' --exclude '.claude/*' --exclude 'content-pipeline/*' --exclude 'src/*' --exclude 'scripts/*' --exclude '.github/*' --exclude '*.md' --exclude '.mcp.json' --exclude '.gitignore' --exclude 'package.json' --exclude 'package-lock.json' --exclude 'ideas/*' --exclude 'newsletter-samples/*' --exclude 'screenshots/*' --exclude 'interview_answers.md'
         env:
-          AWS_S3_BUCKET: "miketineo.com"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: "."
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          aws s3 sync . s3://miketineo.com \
+            --follow-symlinks \
+            --delete \
+            --exclude '.git/*' \
+            --exclude 'node_modules/*' \
+            --exclude '.claude/*' \
+            --exclude 'content-pipeline/*' \
+            --exclude 'src/*' \
+            --exclude 'scripts/*' \
+            --exclude '.github/*' \
+            --exclude '*.md' \
+            --exclude '.mcp.json' \
+            --exclude '.gitignore' \
+            --exclude 'package.json' \
+            --exclude 'package-lock.json' \
+            --exclude 'yarn.lock' \
+            --exclude 'ideas/*' \
+            --exclude 'newsletter-samples/*' \
+            --exclude 'screenshots/*' \
+            --exclude 'interview_answers.md'
+
       - name: Invalidate CloudFront Cache
-        uses: chetan/invalidate-cloudfront-action@v2
         env:
-          DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          PATHS: "/*"
-          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
 
       - name: Detect New Blog Post
         id: blog_check
@@ -47,7 +72,7 @@ jobs:
             POST_FILE=$(echo "$NEW_POSTS" | head -1)
             POST_SLUG=$(basename "$POST_FILE" .md)
             echo "post_slug=$POST_SLUG" >> $GITHUB_OUTPUT
-            echo "📝 New blog post detected: $POST_SLUG"
+            echo "New blog post detected: $POST_SLUG"
           else
             echo "new_post=false" >> $GITHUB_OUTPUT
             echo "No new blog post in this push"
@@ -59,10 +84,10 @@ jobs:
           POST_SLUG="${{ steps.blog_check.outputs.post_slug }}"
           POST_URL="https://miketineo.com/blog/${POST_SLUG}"
 
-          echo "🎉 Blog Post Published!" >> $GITHUB_STEP_SUMMARY
+          echo "Blog Post Published!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📝 Post: ${POST_SLUG}" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 URL: ${POST_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "Post: ${POST_SLUG}" >> $GITHUB_STEP_SUMMARY
+          echo "URL: ${POST_URL}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Next Steps:" >> $GITHUB_STEP_SUMMARY
           echo "1. Verify live: ${POST_URL}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Replace broken `jakejarvis/s3-sync-action@v0.5.1` with direct `aws s3 sync` CLI (pre-installed on runners)
- Replace `chetan/invalidate-cloudfront-action@v2` with direct `aws cloudfront create-invalidation` CLI
- Bump `actions/checkout` v2 → v4 and `actions/setup-node` v3 → v4 (fixes Node.js 20 deprecation warnings)
- Add `fetch-depth: 2` for blog post detection `git diff`
- Exclude `yarn.lock` from S3 sync

## Why
Deploy has been failing since Nov 2025 — the S3 sync Docker action returns non-zero on warnings (e.g. `Skipping file ideas/ideas. File does not exist`), which blocks CloudFront invalidation. Using the AWS CLI directly is simpler, faster, and doesn't have this issue.

## Test plan
- [ ] Merge and verify GitHub Actions run passes
- [x] Confirm site is live at https://miketineo.com with updated content
- [x] Check CloudFront invalidation completes